### PR TITLE
Implement handle_discarded callback and buffered_count method

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -761,7 +761,6 @@ defmodule GenStage do
     :dispatcher_state,
     :buffer,
     :buffer_keep,
-    mod_handle_discarded: false,
     events: :forward,
     monitors: %{},
     producers: %{},
@@ -1765,7 +1764,6 @@ defmodule GenStage do
         type: :producer,
         buffer: Buffer.new(buffer_size),
         buffer_keep: buffer_keep,
-        mod_handle_discarded: function_exported?(mod, :handle_discarded, 2),
         events: if(demand == :accumulate, do: [], else: :forward),
         dispatcher_mod: dispatcher_mod,
         dispatcher_state: dispatcher_state
@@ -1807,7 +1805,6 @@ defmodule GenStage do
         type: :producer_consumer,
         buffer: Buffer.new(buffer_size),
         buffer_keep: buffer_keep,
-        mod_handle_discarded: function_exported?(mod, :handle_discarded, 2),
         events: {:queue.new(), 0},
         dispatcher_mod: dispatcher_mod,
         dispatcher_state: dispatcher_state
@@ -2344,7 +2341,6 @@ defmodule GenStage do
            mod: mod,
            buffer: buffer,
            buffer_keep: keep,
-           mod_handle_discarded: mod_handle_discarded,
            state: state
          } = stage
        ) do
@@ -2355,7 +2351,7 @@ defmodule GenStage do
         :ok
 
       excess ->
-        if mod_handle_discarded do
+        if function_exported?(mod, :handle_discarded, 2) do
           mod.handle_discarded(excess, state)
         else
           error_msg = 'GenStage producer ~tp has discarded ~tp events from buffer'

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -398,7 +398,7 @@ defmodule GenStage do
   `GenStage`'s internal buffer. In case events are being queued and not being
   consumed, a log message will be emitted when we exceed the `:buffer_size`
   configuration. This behavior can be customized by implementing the optional
-  `c:format_discarded\2` callback.
+  `c:format_discarded/2` callback.
 
   While the implementation above is enough to solve the constraints above,
   a more robust implementation would have tighter control over the events

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1707,9 +1707,9 @@ defmodule GenStage do
   @doc """
   Returns the number of buffered items for a producer.
   """
-  @spec buffered_count(stage) :: non_neg_integer
-  def buffered_count(stage) do
-    call(stage, :"$buffered_count")
+  @spec buffered_count(stage, timeout) :: non_neg_integer
+  def buffered_count(stage, timeout \\ 5000) do
+    call(stage, :"$buffered_count", timeout)
   end
 
   ## Callbacks

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1847,12 +1847,12 @@ defmodule GenStage do
   def handle_call(msg, from, %{mod: mod, state: state} = stage) do
     case mod.handle_call(msg, from, state) do
       {:reply, reply, events, state} when is_list(events) ->
-        stage = dispatch_events(events, length(events), stage)
-        {:reply, reply, %{stage | state: state}}
+        stage = dispatch_events(events, length(events), %{stage | state: state})
+        {:reply, reply, stage}
 
       {:reply, reply, events, state, :hibernate} when is_list(events) ->
-        stage = dispatch_events(events, length(events), stage)
-        {:reply, reply, %{stage | state: state}, :hibernate}
+        stage = dispatch_events(events, length(events), %{stage | state: state})
+        {:reply, reply, stage, :hibernate}
 
       {:stop, reason, reply, state} ->
         {:stop, reason, reply, %{stage | state: state}}

--- a/test/gen_stage_test.exs
+++ b/test/gen_stage_test.exs
@@ -265,7 +265,7 @@ defmodule GenStageTest do
 
   defmodule DiscardedBufferLogger do
     @moduledoc """
-    Logs about the buffered size and any discarded items
+    Logs about any discarded items
     """
 
     use GenStage

--- a/test/gen_stage_test.exs
+++ b/test/gen_stage_test.exs
@@ -263,6 +263,41 @@ defmodule GenStageTest do
     end
   end
 
+  defmodule DiscardedBufferLogger do
+    @moduledoc """
+    Logs about the buffered size and any discarded items
+    """
+
+    use GenStage
+
+    def start_link(init, opts \\ []) do
+      GenStage.start_link(__MODULE__, init, opts)
+    end
+
+    def init(init) do
+      init
+    end
+
+    def sync_queue(stage, events) do
+      GenStage.call(stage, {:queue, events})
+    end
+
+    def handle_call({:queue, events}, _from, state) do
+      {:reply, state, events, state}
+    end
+
+    def handle_discarded(discarded, _state) do
+      :error_logger.info_msg("DiscardedBufferLogger has discarded ~tp events from buffer", [
+        discarded
+      ])
+    end
+
+    def handle_demand(_demand, state) do
+      # We don't care about the demand
+      {:noreply, [], state}
+    end
+  end
+
   test "generates child_spec/1" do
     assert Counter.child_spec([:hello]) == %{
              id: Counter,
@@ -742,6 +777,44 @@ defmodule GenStageTest do
       :ok = GenStage.async_subscribe(consumer, to: producer, max_demand: 4, min_demand: 0)
       assert_receive {:consumed, [:a, :b, :c, :d]}
       assert_receive {:consumed, [:e, :f, :g, :h]}
+    end
+
+    test "calls optional handle_discarded callback with discarded count when it exceeds configured size" do
+      {:ok, producer} =
+        DiscardedBufferLogger.start_link({:producer, 0, buffer_size: 5, buffer_keep: :first})
+
+      log =
+        capture_log(fn ->
+          DiscardedBufferLogger.sync_queue(producer, [:a, :b, :c, :d, :e, :f, :g, :h])
+        end)
+
+      assert log =~ "DiscardedBufferLogger has discarded 3 events from buffer"
+
+      log =
+        capture_log(fn ->
+          {:ok, consumer} = Forwarder.start_link({:consumer, self()})
+          :ok = GenStage.async_subscribe(consumer, to: producer, max_demand: 4, min_demand: 0)
+          assert_receive {:consumed, [:a, :b, :c, :d]}
+          assert_receive {:consumed, [:e]}
+        end)
+
+      assert log =~ ""
+    end
+
+    test "returns the correct buffer count when polled" do
+      {:ok, producer} = Counter.start_link({:producer, 0, buffer_size: :infinity})
+      0 = Counter.sync_queue(producer, [:a, :b, :c, :d, :e])
+      assert 5 == GenStage.buffered_count(producer)
+
+      0 = Counter.sync_queue(producer, [:f, :g, :h])
+      assert 8 == GenStage.buffered_count(producer)
+
+      {:ok, consumer} = Forwarder.start_link({:consumer, self()})
+      :ok = GenStage.async_subscribe(consumer, to: producer, max_demand: 4, min_demand: 0)
+      assert_receive {:consumed, [:a, :b, :c, :d]}
+      assert_receive {:consumed, [:e, :f, :g, :h]}
+
+      assert 0 == GenStage.buffered_count(producer)
     end
   end
 


### PR DESCRIPTION
This is a new approach to getting the buffer count and number of discarded items.
The callback is different from the other PR, so now it's only called when something is discarded.
I added a new method to get the buffer count, which should be much more efficient than polling the full state when the buffer is very large.